### PR TITLE
Update Gradle wrapper and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
+build/
 .idea/
 .gradle/
-.out/
-build/
-*.iws
-
-# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
+local.properties
+*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ group = 'io.github.ddimtirov.gradle'
 version = System.getenv('VERSION') ?: version
 
 repositories.jcenter()
-dependencies.implementation 'net.bytebuddy:byte-buddy:1.10.1'
+dependencies.implementation 'net.bytebuddy:byte-buddy:1.10.2'
 
 targetCompatibility = 1.6
 sourceCompatibility = 1.6
@@ -39,7 +39,7 @@ shadowJar {
     assemble.dependsOn it
 }
 
-publishing{
+publishing {
     publications {
         agent(MavenPublication) { publication ->
             project.shadow.component(publication)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
A couple more updates here:

- Gradle wrapper 5.6.4
- byte-buddy 1.10.2
- Small update to `.gitignore` (now also ignoring `*.iml` and `local.properties`)