### PR TITLE
Update byte-buddy to 1.10.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ group = 'io.github.ddimtirov.gradle'
 version = System.getenv('VERSION') ?: version
 
 repositories.jcenter()
-dependencies.implementation 'net.bytebuddy:byte-buddy:1.10.2'
+dependencies.implementation 'net.bytebuddy:byte-buddy:1.10.10'
 
 targetCompatibility = 1.6
 sourceCompatibility = 1.6


### PR DESCRIPTION
This updates [Byte Buddy](https://github.com/raphw/byte-buddy) to [1.10.10](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.10.10)