### PR TITLE
Update byte-buddy and remove deprecated feature flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ group = 'io.github.ddimtirov.gradle'
 version = System.getenv('VERSION') ?: version
 
 repositories.jcenter()
-dependencies.implementation 'net.bytebuddy:byte-buddy:1.10.10'
+dependencies.implementation 'net.bytebuddy:byte-buddy:1.10.12'
 
 targetCompatibility = 1.6
 sourceCompatibility = 1.6

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
 rootProject.name = 'gwo-agent'
-enableFeaturePreview('STABLE_PUBLISHING')


### PR DESCRIPTION
A couple of quick commits here:

- byte-buddy `1.10.12`
- remove `enableFeaturePreview('STABLE_PUBLISHING')` from `settings.gradle`

The feature preview call no longer has any effect. From the [docs](https://docs.gradle.org/current/userguide/upgrading_version_4.html#other_changes):
> The enableFeaturePreview('IMPROVED_POM_SUPPORT') and enableFeaturePreview('STABLE_PUBLISHING') flags are no longer necessary. These features are now enabled by default.

<sub><sup>Once approved, please use a *normal* GitHub merge (i.e. **NO rebase/squash** merge) to integrate the commit(s) from the PR head branch. The changes are broken up into meaningful, [atomic commits](https://www.freshconsulting.com/atomic-commits/), and my branch should already be up-to-date with the latest base branch. If it isn't, or if you want me to change anything, please let me know, and I will update the branch as soon as possible. Thank you!</sup></sub>